### PR TITLE
Fix detecting the concrete5 CLI entry point

### DIFF
--- a/c5
+++ b/c5
@@ -53,11 +53,6 @@ c5_getCliEntrypoint () {
         unset -v __C5_TMPVAR
         return 1
     fi
-    if test -f "${__C5_TMPVAR}concrete/bin/concrete5.php"; then
-        printf '%sconcrete/bin/concrete5.php' "${__C5_TMPVAR}"
-        unset -v __C5_TMPVAR
-        return 0
-    fi
     if test -f "${__C5_TMPVAR}concrete/bin/concrete5"; then
         printf '%sconcrete/bin/concrete5' "${__C5_TMPVAR}"
         unset -v __C5_TMPVAR


### PR DESCRIPTION
In [concrete5 5.7](https://github.com/concrete5/concrete5/tree/5.7.5.13/web/concrete/bin) we had both `concrete/bin/concrete5` and `concrete/bin/concrete5.php`.
Even if the first one was a bash script that calls the secondone, the actual entry point (the executable one) is the first one.

So, let's always resolve it it.
