### PR TITLE
Don't use sudo if user is already the requested one

### DIFF
--- a/c5
+++ b/c5
@@ -79,7 +79,7 @@ c5 () (
     if test -z "$__C5_TMPVAR"; then
         return 255
     fi
-    if test -z "$C5_SUDOAS"; then
+    if test -z "$C5_SUDOAS" || test "$C5_SUDOAS" = "$(whoami)"; then
         "$__C5_TMPVAR" "$@"
         return $?
     fi


### PR DESCRIPTION
If the `C5_SUDOAS` is set to an user name (eg `www-data`) and the `c5` script is already being executed by the same user (eg `www-data`), we may have this error:

```
www-data is not in the sudoers file. This incident will be reported.
```

Let's avoid this.